### PR TITLE
Fixed bugs in AnimationController.launchTo()

### DIFF
--- a/lib/src/animation_controller.dart
+++ b/lib/src/animation_controller.dart
@@ -356,7 +356,7 @@ class RubberAnimationController extends Animation<double>
   TickerFuture launchTo(AnimationState targetState) {
     final targetBound = getBoundFromState(targetState);
     final currentBound = getBoundFromState(animationState);
-    final direction = targetBound < currentBound ? -1.0 : targetBound > currentBound ? 1.0 : 0;
+    final direction = targetBound < currentBound ? -1.0 : targetBound > currentBound ? 1.0 : 0.0;
     return launch(min(targetBound,currentBound), max(targetBound,currentBound),velocity: launchSpeed*(direction));
   }
   TickerFuture launch(double from, double to, { double velocity = 1.0, AnimationBehavior animationBehavior }) {

--- a/lib/src/animation_controller.dart
+++ b/lib/src/animation_controller.dart
@@ -354,12 +354,9 @@ class RubberAnimationController extends Animation<double>
 
   final double launchSpeed = 7;
   TickerFuture launchTo(AnimationState targetState) {
-    var targetBound = getBoundFromState(targetState);
-    var currentBound = getBoundFromState(animationState);
-    var direction = 0.0;
-    if((targetBound-currentBound) != 0) {
-      direction = (targetBound - currentBound) / (targetBound - currentBound);
-    }
+    final targetBound = getBoundFromState(targetState);
+    final currentBound = getBoundFromState(animationState);
+    final direction = targetBound < currentBound ? -1.0 : targetBound > currentBound ? 1.0 : 0;
     return launch(min(targetBound,currentBound), max(targetBound,currentBound),velocity: launchSpeed*(direction));
   }
   TickerFuture launch(double from, double to, { double velocity = 1.0, AnimationBehavior animationBehavior }) {

--- a/lib/src/animation_controller.dart
+++ b/lib/src/animation_controller.dart
@@ -361,7 +361,7 @@ class RubberAnimationController extends Animation<double>
   }
   TickerFuture launch(double from, double to, { double velocity = 1.0, AnimationBehavior animationBehavior }) {
     // no animation necessary
-    if((to - from) * velocity <= 0)
+    if(to == from)
       return TickerFuture.complete();
     final double target = velocity < 0.0 ? from : to;
     double scale = 1.0;

--- a/lib/src/animation_controller.dart
+++ b/lib/src/animation_controller.dart
@@ -356,10 +356,13 @@ class RubberAnimationController extends Animation<double>
   TickerFuture launchTo(AnimationState targetState) {
     final targetBound = getBoundFromState(targetState);
     final currentBound = getBoundFromState(animationState);
-    final direction = targetBound < currentBound ? -1.0 : targetBound > currentBound ? 1.0 : 0.0;
+    final direction = targetBound < currentBound ? -1.0 : 1.0;
     return launch(min(targetBound,currentBound), max(targetBound,currentBound),velocity: launchSpeed*(direction));
   }
   TickerFuture launch(double from, double to, { double velocity = 1.0, AnimationBehavior animationBehavior }) {
+    // no animation necessary
+    if((to - from) * velocity <= 0)
+      return TickerFuture.complete();
     final double target = velocity < 0.0 ? from : to;
     double scale = 1.0;
     final AnimationBehavior behavior = animationBehavior ?? this.animationBehavior;


### PR DESCRIPTION
I noticed a bug: when I call:
```
   bottomSheetController.launchTo(AnimationState.collapsed);
```
The bottom sheet disappears, but then appears again in 20 seconds. That's weird. After some debugging, I found that the animation that's supposed to collapse the bottom sheet, never ends, and `_value` gets set to 1.0 suddenly after 20 seconds. Further debugging revealed that the root cause was the direction that was set incorrectly to 1.0 whereas it should be -1.0 in case of collapsing the popup. In fact, by looking at animation_controller.dart:361 it's obvious that direction will always be equal to 1.0. After my fix, everything started working well and the animation stops when it should.

While reviewing my changes, I noticed that the code might also not be handling correctly the case where `targetBound == currentBound`. Indeed, that results in a never-ending animation as well. I fixed that in `launch()`.