### PR TITLE
Proper fix for issue #7: crash when dragging bellow 0 height

### DIFF
--- a/lib/src/animation_controller.dart
+++ b/lib/src/animation_controller.dart
@@ -202,7 +202,7 @@ class RubberAnimationController extends Animation<double>
   }
 
   void _internalSetValue(double newValue) {
-    _value = newValue;
+    _value = newValue.clamp(lowerBound, upperBound);
     if (_value == lowerBound || _value == halfBound || _value == upperBound || _value == 0) {
       _status = AnimationStatus.completed;
     } else {

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -107,7 +107,7 @@ class _RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvid
     return Align(
       alignment: Alignment.bottomLeft,
       child: FractionallySizedBox(
-        heightFactor: widget.animationController.value >= 0 ? widget.animationController.value : 0,
+        heightFactor: widget.animationController.value,
         child: child
       )
     );


### PR DESCRIPTION
I replaced the temporary fix with a proper fix that ensures that animation value always stays within lower and upper bounds.