### PR TITLE
fix drag / scroll issue

### DIFF
--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -155,7 +155,6 @@ class _RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvid
 
   void _onVerticalDragDown(DragDownDetails details) {
     if(_shouldScroll) {
-      assert(_drag == null);
       assert(_hold == null);
       _hold = _scrollController.position.hold(_disposeHold);
     }


### PR DESCRIPTION
This PR fixes [this](https://github.com/mcrovero/rubber/issues/16) issue.

Basically, user can drag the bottomsheet even when `item 0` is listed which means the `_drag` is not null when user tries to perform drag. Hence, the `assert _drag == null` line was throwing error. I just removed that line and confirmed that dragging the bottomsheet opens the listview properly without throwing any errors in the console.

