### PR TITLE
Add onCollapse callback

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,25 @@
-Copyright 2018, the Rubber project authors. All rights reserved.
+BSD 2-Clause License
+
+Copyright (c) 2018, Mattia Crovero
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the Rubber project nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL RUBBER BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -16,7 +16,12 @@ class RubberBottomSheet extends StatefulWidget {
     @required this.lowerLayer,
     @required this.upperLayer,
     this.menuLayer,
-    this.scrollController, this.header, this.headerHeight=50.0, this.dragFriction=0.52, this.onDragEnd})
+    this.scrollController,
+    this.header,
+    this.headerHeight=50.0,
+    this.dragFriction=0.52,
+    this.onDragEnd,
+    this.onCollapse})
       : assert(animationController!=null),
         super(key: key);
 
@@ -25,6 +30,9 @@ class RubberBottomSheet extends StatefulWidget {
   final Widget upperLayer;
   final Widget menuLayer;
   final double dragFriction;
+
+  /// Called after the bottomsheet collapse
+  final Function() onCollapse;
 
   /// Called when the user stops scrolling, if this function returns a false the bottomsheet 
   /// won't complete the nect onDragEnd instructions
@@ -250,6 +258,14 @@ class RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvide
     }
   }
 
+  void _collapse() {
+    _controller.collapse();
+
+    if (widget.onCollapse != null) {
+      widget.onCollapse();
+    }
+  }
+
   void _onVerticalDragEnd(DragEndDetails details) {
     // If onDragEnd returns a false value the method interrupts
     if(widget.onDragEnd != null) {
@@ -285,7 +301,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvide
                 (_controller.halfBound + _controller.lowerBound) / 2) {
               _controller.halfExpand();
             } else {
-              _controller.collapse();
+              _collapse();
             }
           }
         } else {
@@ -297,7 +313,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvide
             if (_controller.value > (_controller.upperBound + _controller.lowerBound) / 2) {
               _controller.expand();
             } else {
-              _controller.collapse();
+              _collapse();
             }
           }
         }

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -78,6 +78,13 @@ class RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvide
   ScrollController substituteScrollController;
   ScrollController get _scrollController => substituteScrollController ?? widget.scrollController;
 
+  /// If set true the drag won't move the bottomsheet but the scrolling will be always active
+  bool _forceScrolling = false;
+  forceScroll(bool force) {
+    _forceScrolling = force;
+    _setScrolling(force);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -184,7 +191,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvide
       } else {
         _setScrolling(true);
       }
-    }
+    } 
     if(_shouldScroll) {
       assert(_hold == null);
       _hold = _scrollController.position.hold(_disposeHold);
@@ -199,7 +206,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvide
       // _drag might be null if the drag activity ended and called _disposeDrag.
       assert(_hold == null || _drag == null);
       _drag?.update(details);
-      if(_scrollController.position.pixels <= 0 && details.primaryDelta>0) {
+      if(_scrollController.position.pixels <= 0 && details.primaryDelta>0 && !_forceScrolling) {
         _setScrolling(false);
         _handleDragCancel();
         if(_scrollController.position.pixels != 0.0) {
@@ -225,7 +232,6 @@ class RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvide
       }
 
       _controller.value -= details.primaryDelta / screenHeight * friction;
-      print("dragging peak ${_draggingPeak(_lastPosition)}");
       if(_shouldScroll && _controller.value >= _controller.upperBound && !_draggingPeak(_lastPosition)) {
         _controller.value = _controller.upperBound;
         
@@ -293,12 +299,10 @@ class RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvide
                   velocity: flingVelocity);
             }
           } else {
-            if (_controller.value >
-                (_controller.upperBound + _controller.halfBound) / 2) {
+            if (_controller.value > (_controller.upperBound + _controller.halfBound) / 2) {
               _controller.expand();
             }
-            else if (_controller.value >
-                (_controller.halfBound + _controller.lowerBound) / 2) {
+            else if (_controller.value > (_controller.halfBound + _controller.lowerBound) / 2) {
               _controller.halfExpand();
             } else {
               _collapse();
@@ -306,10 +310,8 @@ class RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvide
           }
         } else {
           if (details.velocity.pixelsPerSecond.dy.abs() > _kMinFlingVelocity) {
-            _controller.fling(_controller.lowerBound, _controller.upperBound,
-                velocity: flingVelocity);
+            _controller.fling(_controller.lowerBound, _controller.upperBound, velocity: flingVelocity);
           } else {
-            print("${_controller.value} - ${_controller.upperBound} - ${_controller.lowerBound}");
             if (_controller.value > (_controller.upperBound + _controller.lowerBound) / 2) {
               _controller.expand();
             } else {
@@ -355,6 +357,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet> with TickerProvide
     final top = (sizePeak.height + positionPeak.dy);
     return (globalPosition.dy < top);
   }
+
 }
 
 class RubberBottomSheetScope extends InheritedWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: after_layout
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.7"
+    version: "1.0.7+1"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.4"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   after_layout: ^1.0.7
-
+  
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
First of all, congrats, this widget works pretty good.
Using it i had the need to execute some tasks after the bottom sheet collapse and i thought this could be useful for someone else too. So i added this optional callback: onCollapse.

Situations that can be useful
If your bottom sheet content has managed data or if you need to update some state on the parent widget, is good to know when the bottom sheet is collapsed.