### PR TITLE
Change Deprecated API ancestorStateOfType

### DIFF
--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -56,7 +56,7 @@ class RubberBottomSheet extends StatefulWidget {
     assert(nullOk != null);
     assert(context != null);
     final RubberBottomSheetState result = context
-        .ancestorStateOfType(const TypeMatcher<RubberBottomSheetState>());
+        .findAncestorStateOfType<RubberBottomSheetState>();
     if (nullOk || result != null) return result;
     throw FlutterError(
         'RubberBottomSheet.of() called with a context that does not contain a RubberBottomSheet.\n'


### PR DESCRIPTION
Hello,

A change in the SDK caused my code to break in Flutter 1.26.0-2.0.pre.335. Adding this change in bottom_sheet.dart seemed to help. More information about the depreciated API can be found [here](https://groups.google.com/g/flutter-announce/c/RS82mg9iK24/m/9PX-hybyAAAJ).

Thanks!