### PR TITLE
Disable content scrolling when sheet is not expanded

### DIFF
--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -85,7 +85,9 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
   bool get halfState => controller.halfBound != null;
 
   bool get _shouldScroll =>
-      _scrollController != null && _scrollController.hasClients;
+      _scrollController != null &&
+      _scrollController.hasClients &&
+      controller.value >= controller.upperBound;
   bool _scrolling = false;
 
   bool get _hasHeader => widget.header != null;


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/mcrovero/rubber/issues/39) by allowing the sheet content to be scrolled only when the sheet it's expanded.