### PR TITLE
[depends on nullsafety] Friction fix revived

### DIFF
--- a/example/lib/default.dart
+++ b/example/lib/default.dart
@@ -8,8 +8,8 @@ class DefaultPage extends StatefulWidget {
   _DefaultPageState createState() => _DefaultPageState();
 }
 
-class _DefaultPageState extends State<DefaultPage> with SingleTickerProviderStateMixin {
-
+class _DefaultPageState extends State<DefaultPage>
+    with SingleTickerProviderStateMixin {
   RubberAnimationController _controller;
 
   @override
@@ -18,8 +18,7 @@ class _DefaultPageState extends State<DefaultPage> with SingleTickerProviderStat
         vsync: this,
         halfBoundValue: AnimationControllerValue(percentage: 0.5),
         lowerBoundValue: AnimationControllerValue(pixel: 200),
-        duration: Duration(milliseconds: 200)
-    );
+        duration: Duration(milliseconds: 200));
     _controller.addStatusListener(_statusListener);
     _controller.animationState.addListener(_stateListener);
     super.initState();
@@ -48,7 +47,10 @@ class _DefaultPageState extends State<DefaultPage> with SingleTickerProviderStat
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("Default",style: TextStyle(color: Colors.cyan[900]),),
+        title: Text(
+          "Default",
+          style: TextStyle(color: Colors.cyan[900]),
+        ),
       ),
       body: Container(
         child: RubberBottomSheet(
@@ -86,16 +88,13 @@ class _DefaultPageState extends State<DefaultPage> with SingleTickerProviderStat
 
   Widget _getLowerLayer() {
     return Container(
-      decoration: BoxDecoration(
-          color: Colors.cyan[100]
-      ),
+      decoration: BoxDecoration(color: Colors.cyan[100]),
     );
   }
+
   Widget _getUpperLayer() {
     return Container(
-      decoration: BoxDecoration(
-          color: Colors.cyan
-      ),
+      decoration: BoxDecoration(color: Colors.cyan),
     );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,10 @@
-import 'package:example/dismissable.dart';
-import 'package:example/scroll.dart';
-import 'package:example/spring.dart';
 import 'package:flutter/material.dart';
 import 'package:example/default.dart';
 import 'package:example/menu.dart';
+import 'package:example/spring.dart';
+import 'package:example/padding.dart';
+import 'package:example/scroll.dart';
+import 'package:example/dismissable.dart';
 
 void main() => runApp(MyApp());
 
@@ -68,6 +69,15 @@ class _HomePageState extends State<HomePage>
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (context) => SpringPage()),
+              );
+            },
+          ),
+          ElevatedButton(
+            child: Text("Animation Padding"),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => AnimationPaddingPage()),
               );
             },
           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,7 +8,6 @@ import 'package:example/menu.dart';
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -16,11 +15,12 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primaryColor: Colors.cyan,
       ),
-      home: HomePage(title: "Home",),
+      home: HomePage(
+        title: "Home",
+      ),
     );
   }
 }
-
 
 class HomePage extends StatefulWidget {
   HomePage({Key key, this.title}) : super(key: key);
@@ -31,63 +31,66 @@ class HomePage extends StatefulWidget {
   _HomePageState createState() => _HomePageState();
 }
 
-class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin {
-
+class _HomePageState extends State<HomePage>
+    with SingleTickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: Text(widget.title,style: TextStyle(color: Colors.cyan[900]),),
+      appBar: AppBar(
+        title: Text(
+          widget.title,
+          style: TextStyle(color: Colors.cyan[900]),
         ),
-        body: ListView(
-          children: <Widget>[
-            RaisedButton(
-              child: Text("Default"),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => DefaultPage()),
-                );
-              },
-            ),
-            RaisedButton(
-              child: Text("Menu"),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => MenuPage()),
-                );
-              },
-            ),
-            RaisedButton(
-              child: Text("Spring settings"),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => SpringPage()),
-                );
-              },
-            ),
-            RaisedButton(
-              child: Text("Scrolling"),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => ScrollPage()),
-                );
-              },
-            ),
-            RaisedButton(
-              child: Text("Dismissable"),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => DismissablePage()),
-                );
-              },
-            ),
-          ],
-        ),
+      ),
+      body: ListView(
+        children: <Widget>[
+          ElevatedButton(
+            child: Text("Default"),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => DefaultPage()),
+              );
+            },
+          ),
+          ElevatedButton(
+            child: Text("Menu"),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => MenuPage()),
+              );
+            },
+          ),
+          ElevatedButton(
+            child: Text("Spring settings"),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => SpringPage()),
+              );
+            },
+          ),
+          ElevatedButton(
+            child: Text("Scrolling"),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => ScrollPage()),
+              );
+            },
+          ),
+          ElevatedButton(
+            child: Text("Dismissable"),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => DismissablePage()),
+              );
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/example/lib/menu.dart
+++ b/example/lib/menu.dart
@@ -8,32 +8,36 @@ class MenuPage extends StatefulWidget {
   _MenuPageState createState() => _MenuPageState();
 }
 
-class _MenuPageState extends State<MenuPage> with SingleTickerProviderStateMixin {
-
+class _MenuPageState extends State<MenuPage>
+    with SingleTickerProviderStateMixin {
   RubberAnimationController _controller;
 
   @override
   void initState() {
     _controller = RubberAnimationController(
-        vsync: this,
-        dismissable: true,
-        lowerBoundValue: AnimationControllerValue(pixel: 100),
-        upperBoundValue: AnimationControllerValue(pixel: 400),
-        duration: Duration(milliseconds: 200)
+      vsync: this,
+      dismissable: true,
+      lowerBoundValue: AnimationControllerValue(pixel: 100),
+      upperBoundValue: AnimationControllerValue(pixel: 400),
+      duration: Duration(milliseconds: 200),
     );
     super.initState();
   }
 
   void _expand() {
     print("expand");
-    _controller.launchTo(_controller.value,_controller.upperBound,velocity: 2);
+    _controller.launchTo(_controller.value, _controller.upperBound,
+        velocity: 2);
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("Menu",style: TextStyle(color: Colors.cyan[900]),),
+        title: Text(
+          "Menu",
+          style: TextStyle(color: Colors.cyan[900]),
+        ),
       ),
       body: Container(
         child: RubberBottomSheet(
@@ -55,28 +59,23 @@ class _MenuPageState extends State<MenuPage> with SingleTickerProviderStateMixin
 
   Widget _getLowerLayer() {
     return Container(
-      decoration: BoxDecoration(
-          color: Colors.cyan[100]
-      ),
+      decoration: BoxDecoration(color: Colors.cyan[100]),
     );
   }
+
   Widget _getUpperLayer() {
     return Container(
-      decoration: BoxDecoration(
-          color: Colors.cyan
-      ),
+      decoration: BoxDecoration(color: Colors.cyan),
     );
   }
+
   Widget _getMenuLayer() {
     return Container(
       height: 100,
       child: Center(
         child: Text("MENU"),
       ),
-      decoration: BoxDecoration(
-        color: Colors.red
-      ),
+      decoration: BoxDecoration(color: Colors.red),
     );
   }
-
 }

--- a/example/lib/padding.dart
+++ b/example/lib/padding.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:rubber/rubber.dart';
+
+class AnimationPaddingPage extends StatefulWidget {
+  AnimationPaddingPage({Key key}) : super(key: key);
+
+  @override
+  _AnimationPaddingPageState createState() => _AnimationPaddingPageState();
+}
+
+class _AnimationPaddingPageState extends State<AnimationPaddingPage>
+    with SingleTickerProviderStateMixin {
+  RubberAnimationController _controller;
+
+  static final contain = AnimationPadding.contain();
+  static final fivePercent =
+      AnimationPadding.fromPercentages(bottom: 0.05, top: 0.05);
+  static final minus50px = AnimationPadding.fromPixels(top: -50);
+  static final bottomOnly = AnimationPadding.bottomOnly();
+
+  AnimationPadding _padding = contain;
+
+  @override
+  void initState() {
+    _controller = RubberAnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 300),
+      padding: _padding,
+    );
+    super.initState();
+  }
+
+  Row option(AnimationPadding padding, String text) =>
+      Row(mainAxisAlignment: MainAxisAlignment.start, children: <Widget>[
+        SizedBox(width: 32),
+        Radio(
+          value: padding,
+          groupValue: _padding,
+          onChanged: _handleAnimationPaddingChange,
+        ),
+        Text(text),
+      ]);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          "Animation Padding",
+          style: TextStyle(color: Colors.cyan[900]),
+        ),
+      ),
+      body: Column(
+        children: <Widget>[
+          Padding(
+            padding: EdgeInsets.all(16),
+            child: Text(
+                "In this example we see the behavior of a few AnimationPadding options."
+                "The other configurations are the same – the sheet will come to rest at "
+                "10% bounds from the top and bottom of the cyan container."),
+          ),
+          option(contain,
+              "AnimationPadding.contain():\nbounce to edge of containing widget."),
+          option(fivePercent,
+              ".fromPercentages(bottom: 0.05, top: 0.05):\nbounce to within 5% padding\nof containing widget."),
+          option(
+            minus50px,
+            ".fromPixels(top: -50): bounce out of\nthe containing widget by 50px at the top",
+          ),
+          option(
+            bottomOnly,
+            "AnimationPadding.bottomOny()\nbounce beyond top of containing widget\ninfinitely (old default)",
+          ),
+          Expanded(
+            child: RubberBottomSheet(
+              lowerLayer: _getLowerLayer(),
+              upperLayer: _getUpperLayer(),
+              animationController: _controller,
+              header: Container(
+                color: Colors.yellow,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _handleAnimationPaddingChange(AnimationPadding padding) {
+    _padding = padding;
+    setState(() {
+      _controller.padding = _padding;
+    });
+  }
+
+  Widget _getLowerLayer() {
+    return Container(
+      decoration: BoxDecoration(color: Colors.cyan[100]),
+    );
+  }
+
+  Widget _getUpperLayer() {
+    return Container(
+      decoration: BoxDecoration(color: Colors.cyan),
+    );
+  }
+}

--- a/example/lib/spring.dart
+++ b/example/lib/spring.dart
@@ -8,8 +8,8 @@ class SpringPage extends StatefulWidget {
   _SpringPageState createState() => _SpringPageState();
 }
 
-class _SpringPageState extends State<SpringPage> with SingleTickerProviderStateMixin {
-
+class _SpringPageState extends State<SpringPage>
+    with SingleTickerProviderStateMixin {
   RubberAnimationController _controller;
 
   double _dampingValue = DampingRatio.HIGH_BOUNCY;
@@ -22,12 +22,8 @@ class _SpringPageState extends State<SpringPage> with SingleTickerProviderStateM
         lowerBoundValue: AnimationControllerValue(pixel: 100),
         upperBoundValue: AnimationControllerValue(percentage: 0.9),
         springDescription: SpringDescription.withDampingRatio(
-            mass: 1,
-            stiffness: _stiffnessValue,
-            ratio: _dampingValue
-        ),
-        duration: Duration(milliseconds: 300)
-    );
+            mass: 1, stiffness: _stiffnessValue, ratio: _dampingValue),
+        duration: Duration(milliseconds: 300));
     super.initState();
   }
 
@@ -35,11 +31,14 @@ class _SpringPageState extends State<SpringPage> with SingleTickerProviderStateM
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("Spring",style: TextStyle(color: Colors.cyan[900]),),
+        title: Text(
+          "Spring",
+          style: TextStyle(color: Colors.cyan[900]),
+        ),
       ),
       body: Column(
         children: <Widget>[
-          Text("Daming ratio",style: _heading()),
+          Text("Daming ratio", style: _heading()),
           new Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
@@ -69,7 +68,10 @@ class _SpringPageState extends State<SpringPage> with SingleTickerProviderStateM
               new Text('No'),
             ],
           ),
-          Text("Stiffness",style: _heading(),),
+          Text(
+            "Stiffness",
+            style: _heading(),
+          ),
           new Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
@@ -124,32 +126,25 @@ class _SpringPageState extends State<SpringPage> with SingleTickerProviderStateM
       _setController();
     });
   }
-  
+
   Widget _getLowerLayer() {
     return Container(
-      decoration: BoxDecoration(
-          color: Colors.cyan[100]
-      ),
-    );
-  }
-  Widget _getUpperLayer() {
-    return Container(
-      decoration: BoxDecoration(
-          color: Colors.cyan
-      ),
+      decoration: BoxDecoration(color: Colors.cyan[100]),
     );
   }
 
+  Widget _getUpperLayer() {
+    return Container(
+      decoration: BoxDecoration(color: Colors.cyan),
+    );
+  }
 
   void _setController() {
     _controller.springDescription = SpringDescription.withDampingRatio(
-        mass: 1,
-        stiffness: _stiffnessValue,
-        ratio: _dampingValue
-    );
+        mass: 1, stiffness: _stiffnessValue, ratio: _dampingValue);
   }
 
   TextStyle _heading() {
-    return TextStyle(fontSize: 20.0,fontWeight: FontWeight.bold);
+    return TextStyle(fontSize: 20.0, fontWeight: FontWeight.bold);
   }
 }

--- a/lib/src/animation_controller.dart
+++ b/lib/src/animation_controller.dart
@@ -272,7 +272,6 @@ class RubberAnimationController extends Animation<double>
 
   void _resolvePixels(AnimationControllerValue value) {
     final px = value.pixel;
-    print([px, _height]);
     if (px != null && _height > 0.0) {
       value.percentage = (px / _height).toDouble();
     }
@@ -283,7 +282,6 @@ class RubberAnimationController extends Animation<double>
     if (initialValue == null && lowerBound == null) {
       _value = lowerBoundValue.pixel! / _height;
     }
-    print(padding);
     for (final value in [
       lowerBoundValue,
       halfBoundValue,

--- a/lib/src/animation_controller.dart
+++ b/lib/src/animation_controller.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/physics.dart';
@@ -10,12 +8,12 @@ import 'package:rubber/src/spring_description/stiffness.dart';
 
 export 'package:flutter/scheduler.dart' show TickerFuture, TickerCanceled;
 
-final SpringDescription _kFlingSpringDefaultDescription = SpringDescription.withDampingRatio(
+final SpringDescription _kFlingSpringDefaultDescription =
+    SpringDescription.withDampingRatio(
   mass: 1,
   stiffness: Stiffness.LOW,
   ratio: DampingRatio.LOW_BOUNCY,
 );
-
 
 const Tolerance _kFlingTolerance = Tolerance(
   velocity: double.infinity,
@@ -30,8 +28,8 @@ enum AnimationState {
 }
 
 class AnimationControllerValue {
-  double percentage;
-  double pixel;
+  double? percentage;
+  double? pixel;
   AnimationControllerValue({this.percentage, this.pixel});
   @override
   String toString() {
@@ -40,8 +38,10 @@ class AnimationControllerValue {
 }
 
 class RubberAnimationController extends Animation<double>
-  with AnimationEagerListenerMixin, AnimationLocalListenersMixin, AnimationLocalStatusListenersMixin {
-
+    with
+        AnimationEagerListenerMixin,
+        AnimationLocalListenersMixin,
+        AnimationLocalStatusListenersMixin {
   /// Creates an animation controller.
   ///
   /// * [value] is the initial value of the animation. If defaults to the lower
@@ -69,7 +69,7 @@ class RubberAnimationController extends Animation<double>
   /// * `vsync` is the [TickerProvider] for the current context. It can be
   ///   changed by calling [resync]. It is required and must not be null. See
   ///   [TickerProvider] for advice on obtaining a ticker provider.
-  
+
   RubberAnimationController({
     this.lowerBoundValue,
     this.halfBoundValue,
@@ -80,43 +80,42 @@ class RubberAnimationController extends Animation<double>
     this.debugLabel,
     this.animationBehavior = AnimationBehavior.normal,
     springDescription,
-    @required TickerProvider vsync,
-  }) : assert(vsync != null), assert(!dismissable || (dismissable && halfBoundValue==null)) {
-    
-    if(springDescription!=null) _springDescription = springDescription;
+    required TickerProvider vsync,
+  }) : assert(!dismissable || (dismissable && halfBoundValue == null)) {
+    if (springDescription != null) _springDescription = springDescription;
 
     _ticker = vsync.createTicker(_tick);
-    if(lowerBoundValue == null){
-      if(dismissable) 
+    if (lowerBoundValue == null) {
+      if (dismissable)
         lowerBoundValue = AnimationControllerValue(percentage: 0.0);
-      else 
+      else
         lowerBoundValue = AnimationControllerValue(percentage: 0.1);
     }
-    if(upperBoundValue == null){
+    if (upperBoundValue == null) {
       upperBoundValue = AnimationControllerValue(percentage: 0.9);
     }
-    if(lowerBound != null)
-      _internalSetValue(initialValue ?? lowerBound);
+    if (lowerBound != null) _internalSetValue(initialValue ?? lowerBound);
   }
 
   /// The value at which this animation is collapsed.
-  AnimationControllerValue lowerBoundValue;
-  double get lowerBound => lowerBoundValue.percentage;
+  AnimationControllerValue? lowerBoundValue;
+  double? get lowerBound => lowerBoundValue!.percentage;
 
   /// The value at which this animation is half expanded
-  AnimationControllerValue halfBoundValue;
-  double get halfBound => halfBoundValue != null ? halfBoundValue.percentage : null;
+  AnimationControllerValue? halfBoundValue;
+  double? get halfBound =>
+      halfBoundValue != null ? halfBoundValue!.percentage : null;
 
   /// The value at which this animation is expanded.
-  AnimationControllerValue upperBoundValue;
-  double get upperBound => upperBoundValue.percentage;
+  AnimationControllerValue? upperBoundValue;
+  double? get upperBound => upperBoundValue!.percentage;
 
   /// Tells if the bottomsheet has to remain closed after drag down
   final bool dismissable;
 
   /// A label that is used in the [toString] output. Intended to aid with
   /// identifying animation controller instances in debug output.
-  final String debugLabel;
+  final String? debugLabel;
 
   /// The behavior of the controller when [AccessibilityFeatures.disableAnimations]
   /// is true.
@@ -137,23 +136,24 @@ class RubberAnimationController extends Animation<double>
   Animation<double> get view => this;
 
   /// The length of time this animation should last.
-  Duration duration;
+  Duration? duration;
 
-  Ticker _ticker;
+  Ticker? _ticker;
 
   /// Recreates the [Ticker] with the new [TickerProvider].
   void resync(TickerProvider vsync) {
-    final Ticker oldTicker = _ticker;
+    final Ticker oldTicker = _ticker!;
     _ticker = vsync.createTicker(_tick);
-    _ticker.absorbTicker(oldTicker);
+    _ticker!.absorbTicker(oldTicker);
   }
 
-  Simulation _simulation;
+  Simulation? _simulation;
 
-  ValueNotifier<AnimationState> animationState = ValueNotifier(AnimationState.collapsed);
+  ValueNotifier<AnimationState> animationState =
+      ValueNotifier(AnimationState.collapsed);
 
   /// Initial value of the controller in percentage
-  double initialValue;
+  double? initialValue;
 
   /// The current value of the animation.
   ///
@@ -164,8 +164,8 @@ class RubberAnimationController extends Animation<double>
   /// running; if this happens, it also notifies all the status
   /// listeners.
   @override
-  double get value => _value;
-  double _value = 0.0;
+  double get value => _value!;
+  double? _value = 0.0;
 
   /// Stops the animation controller and sets the current value of the
   /// animation.
@@ -175,21 +175,20 @@ class RubberAnimationController extends Animation<double>
   /// Value listeners are notified even if this does not change the value.
   /// Status listeners are notified if the animation was previously playing.
   set value(double newValue) {
-    assert(newValue != null);
     stop();
     _internalSetValue(newValue);
     notifyListeners();
     _checkState();
   }
-  
+
   /// Sets the controller's value to [initialValue] or [lowerBound], stopping the animation (if
   /// in progress), and resetting to its beginning point, or collapsed state.
   void reset() {
-    value = initialValue ?? lowerBound;
+    value = initialValue ?? lowerBound!;
   }
 
-  double _height=0.0;
-  set height(double value) {
+  double? _height = 0.0;
+  set height(double? value) {
     _height = value;
     pixelValuesToPercentage();
     value = _value;
@@ -197,17 +196,17 @@ class RubberAnimationController extends Animation<double>
 
   void pixelValuesToPercentage() {
     // sets initial value if lowerbound has only pixel value
-    if(initialValue == null && lowerBound == null) {
-      _value = lowerBoundValue.pixel / _height;
+    if (initialValue == null && lowerBound == null) {
+      _value = lowerBoundValue!.pixel! / _height!;
     }
-    if(lowerBoundValue.pixel != null) {
-      lowerBoundValue.percentage = lowerBoundValue.pixel / _height;
+    if (lowerBoundValue!.pixel != null) {
+      lowerBoundValue!.percentage = lowerBoundValue!.pixel! / _height!;
     }
-    if(halfBoundValue!= null && halfBoundValue.pixel != null) {
-      halfBoundValue.percentage = halfBoundValue.pixel / _height;
+    if (halfBoundValue != null && halfBoundValue!.pixel != null) {
+      halfBoundValue!.percentage = halfBoundValue!.pixel! / _height!;
     }
-    if(upperBoundValue.pixel != null) {
-      upperBoundValue.percentage = upperBoundValue.pixel / _height;
+    if (upperBoundValue!.pixel != null) {
+      upperBoundValue!.percentage = upperBoundValue!.pixel! / _height!;
     }
   }
 
@@ -216,12 +215,12 @@ class RubberAnimationController extends Animation<double>
   /// If [isAnimating] is false, then [value] is not changing and the rate of
   /// change is zero.
   double get velocity {
-    if (!isAnimating)
-      return 0.0;
-    return _simulation.dx(lastElapsedDuration.inMicroseconds.toDouble() / Duration.microsecondsPerSecond);
+    if (!isAnimating) return 0.0;
+    return _simulation!.dx(lastElapsedDuration!.inMicroseconds.toDouble() /
+        Duration.microsecondsPerSecond);
   }
 
-  void _internalSetValue(double newValue) {
+  void _internalSetValue(double? newValue) {
     _value = newValue;
   }
 
@@ -229,8 +228,8 @@ class RubberAnimationController extends Animation<double>
   /// and the most recent tick of the animation.
   ///
   /// If the controller is not animating, the last elapsed duration is null.
-  Duration get lastElapsedDuration => _lastElapsedDuration;
-  Duration _lastElapsedDuration;
+  Duration? get lastElapsedDuration => _lastElapsedDuration;
+  Duration? _lastElapsedDuration;
 
   /// Whether this animation is currently animating in either the forward or reverse direction.
   ///
@@ -238,35 +237,37 @@ class RubberAnimationController extends Animation<double>
   /// controller's ticker might get muted, in which case the animation
   /// controller's callbacks will no longer fire even though time is continuing
   /// to pass. See [Ticker.muted] and [TickerMode].
-  bool get isAnimating => _ticker != null && _ticker.isActive;
+  bool get isAnimating => _ticker != null && _ticker!.isActive;
 
-  /// Tells if the animations is running(forward) or completed 
+  /// Tells if the animations is running(forward) or completed
   @override
   AnimationStatus get status => _status;
   AnimationStatus _status = AnimationStatus.completed;
 
-  TickerFuture expand({ double from }) {
+  TickerFuture expand({double? from}) {
     return animateTo(from: from, to: upperBound);
   }
-  TickerFuture halfExpand({ double from }) {
+
+  TickerFuture halfExpand({double? from}) {
     return animateTo(from: from, to: halfBound);
   }
-  TickerFuture collapse({ double from }) {
+
+  TickerFuture collapse({double? from}) {
     return animateTo(from: from, to: lowerBound);
   }
-  TickerFuture animateTo({ double from, double to, Curve curve = Curves.easeOut }) { 
+
+  TickerFuture animateTo(
+      {double? from, double? to, Curve curve = Curves.easeOut}) {
     assert(() {
       if (duration == null) {
         throw FlutterError(
             'AnimationController.collapse() called with no default Duration.\n'
-                'The "duration" property should be set, either in the constructor or later, before '
-                'calling the collapse() function.'
-        );
+            'The "duration" property should be set, either in the constructor or later, before '
+            'calling the collapse() function.');
       }
       return true;
     }());
-    if (from != null)
-      value = from;
+    if (from != null) value = from;
     return _animateToInternal(to, curve: curve);
   }
 
@@ -277,29 +278,29 @@ class RubberAnimationController extends Animation<double>
 
   void _checkState() {
     var roundValue = double.parse(value.toStringAsFixed(2));
-    var roundLowerBound = double.parse(lowerBound.toStringAsFixed(2));
+    var roundLowerBound = double.parse(lowerBound!.toStringAsFixed(2));
     var roundHalfBound = 0.0;
-    if(halfBound != null) 
-      roundHalfBound = double.parse(halfBound.toStringAsFixed(2));
-    var roundUppperBound = double.parse(upperBound.toStringAsFixed(2));
+    if (halfBound != null)
+      roundHalfBound = double.parse(halfBound!.toStringAsFixed(2));
+    var roundUppperBound = double.parse(upperBound!.toStringAsFixed(2));
 
-    if(roundValue == roundLowerBound) {
+    if (roundValue == roundLowerBound) {
       animationState.value = AnimationState.collapsed;
-    }
-    else if(halfBound != null && roundValue == roundHalfBound) {
+    } else if (halfBound != null && roundValue == roundHalfBound) {
       animationState.value = AnimationState.half_expanded;
-    }
-    else if(roundValue == roundUppperBound) {
+    } else if (roundValue == roundUppperBound) {
       animationState.value = AnimationState.expanded;
     } else {
       animationState.value = AnimationState.animating;
     }
   }
 
-  TickerFuture _animateToInternal(double target, { Curve curve = Curves.easeOut, AnimationBehavior animationBehavior }) {
-    final AnimationBehavior behavior = animationBehavior ?? this.animationBehavior;
+  TickerFuture _animateToInternal(double? target,
+      {Curve curve = Curves.easeOut, AnimationBehavior? animationBehavior}) {
+    final AnimationBehavior behavior =
+        animationBehavior ?? this.animationBehavior;
     double scale = 1.0;
-    if (SemanticsBinding.instance.disableAnimations) {
+    if (SemanticsBinding.instance!.disableAnimations) {
       switch (behavior) {
         case AnimationBehavior.normal:
           scale = 0.05;
@@ -308,22 +309,22 @@ class RubberAnimationController extends Animation<double>
           break;
       }
     }
-    Duration simulationDuration = duration;
+    Duration? simulationDuration = duration;
     if (simulationDuration == null) {
       assert(() {
         if (this.duration == null) {
           throw FlutterError(
               'AnimationController.animateTo() called with no explicit Duration and no default Duration.\n'
-                  'Either the "duration" argument to the animateTo() method should be provided, or the '
-                  '"duration" property should be set, either in the constructor or later, before '
-                  'calling the animateTo() function.'
-          );
+              'Either the "duration" argument to the animateTo() method should be provided, or the '
+              '"duration" property should be set, either in the constructor or later, before '
+              'calling the animateTo() function.');
         }
         return true;
       }());
-      final double range = upperBound - lowerBound;
-      final double remainingFraction = range.isFinite ? (target - _value).abs() / range : 1.0;
-      simulationDuration = this.duration * remainingFraction;
+      final double range = upperBound! - lowerBound!;
+      final double remainingFraction =
+          range.isFinite ? (target! - _value!).abs() / range : 1.0;
+      simulationDuration = this.duration! * remainingFraction;
     } else if (target == value) {
       // Already at target, don't animate.
       simulationDuration = Duration.zero;
@@ -340,11 +341,12 @@ class RubberAnimationController extends Animation<double>
     }
     assert(simulationDuration > Duration.zero);
     assert(!isAnimating);
-    return _startSimulation(_InterpolationSimulation(_value, target, simulationDuration, curve, scale));
+    return _startSimulation(_InterpolationSimulation(
+        _value!, target!, simulationDuration, curve, scale));
   }
 
-  double getBoundFromState(AnimationState state) {
-    switch(state) {
+  double? getBoundFromState(AnimationState state) {
+    switch (state) {
       case AnimationState.collapsed:
         return lowerBound;
       case AnimationState.half_expanded:
@@ -354,18 +356,21 @@ class RubberAnimationController extends Animation<double>
       case AnimationState.animating:
         return null;
     }
-    return 1;
   }
 
-  TickerFuture fling(double from, double to, { double velocity = 1.0, AnimationBehavior animationBehavior }) {
-    final double target = velocity < 0.0 ? from : to;
-    return launchTo(value,target,velocity: velocity, animationBehavior: animationBehavior);
+  TickerFuture fling(double? from, double? to,
+      {double velocity = 1.0, AnimationBehavior? animationBehavior}) {
+    final double? target = velocity < 0.0 ? from : to;
+    return launchTo(value, target,
+        velocity: velocity, animationBehavior: animationBehavior);
   }
 
-  TickerFuture launchTo(double from, double to, { double velocity = 1.0, AnimationBehavior animationBehavior }) {
+  TickerFuture launchTo(double from, double? to,
+      {double velocity = 1.0, AnimationBehavior? animationBehavior}) {
     double scale = 1.0;
-    final AnimationBehavior behavior = animationBehavior ?? this.animationBehavior;
-    if (SemanticsBinding.instance.disableAnimations) {
+    final AnimationBehavior behavior =
+        animationBehavior ?? this.animationBehavior;
+    if (SemanticsBinding.instance!.disableAnimations) {
       switch (behavior) {
         case AnimationBehavior.normal:
           scale = 200.0;
@@ -374,9 +379,10 @@ class RubberAnimationController extends Animation<double>
           break;
       }
     }
-    
-    final Simulation simulation = SpringSimulation(_springDescription, from, to, velocity * scale)
-      ..tolerance = _kFlingTolerance;
+
+    final Simulation simulation =
+        SpringSimulation(_springDescription, from, to!, velocity * scale)
+          ..tolerance = _kFlingTolerance;
     return animateWith(simulation);
   }
 
@@ -389,12 +395,11 @@ class RubberAnimationController extends Animation<double>
   }
 
   TickerFuture _startSimulation(Simulation simulation) {
-    assert(simulation != null);
     assert(!isAnimating);
     _simulation = simulation;
     _lastElapsedDuration = Duration.zero;
     _value = simulation.x(0.0);
-    final TickerFuture result = _ticker.start();
+    final TickerFuture result = _ticker!.start();
     _status = AnimationStatus.forward;
     notifyStatusListeners(_status);
     return result;
@@ -404,10 +409,10 @@ class RubberAnimationController extends Animation<double>
   ///
   /// This does not trigger any notifications. The animation stops in its
   /// current state.
-  void stop({ bool canceled = true }) {
+  void stop({bool canceled = true}) {
     _simulation = null;
     _lastElapsedDuration = null;
-    _ticker.stop(canceled: canceled);
+    _ticker!.stop(canceled: canceled);
   }
 
   /// Release the resources used by this object. The object is no longer usable
@@ -418,27 +423,27 @@ class RubberAnimationController extends Animation<double>
       if (_ticker == null) {
         throw FlutterError(
             'AnimationController.dispose() called more than once.\n'
-                'A given $runtimeType cannot be disposed more than once.\n'
-                'The following $runtimeType object was disposed multiple times:\n'
-                '  $this'
-        );
+            'A given $runtimeType cannot be disposed more than once.\n'
+            'The following $runtimeType object was disposed multiple times:\n'
+            '  $this');
       }
       return true;
     }());
-    _ticker.dispose();
+    _ticker!.dispose();
     _ticker = null;
     super.dispose();
   }
 
   void _tick(Duration elapsed) {
     _lastElapsedDuration = elapsed;
-    final double elapsedInSeconds = elapsed.inMicroseconds.toDouble() / Duration.microsecondsPerSecond;
+    final double elapsedInSeconds =
+        elapsed.inMicroseconds.toDouble() / Duration.microsecondsPerSecond;
     assert(elapsedInSeconds >= 0.0);
-    _value = _simulation.x(elapsedInSeconds);
-    if(_simulation.isDone(elapsedInSeconds) || (dismissable && _value<lowerBound && elapsedInSeconds > 0)) {
-      if(_value < lowerBound && dismissable) 
-        _value = lowerBound;
-      
+    _value = _simulation!.x(elapsedInSeconds);
+    if (_simulation!.isDone(elapsedInSeconds) ||
+        (dismissable && _value! < lowerBound! && elapsedInSeconds > 0)) {
+      if (_value! < lowerBound! && dismissable) _value = lowerBound;
+
       _status = AnimationStatus.completed;
       notifyStatusListeners(_status);
       stop();
@@ -450,19 +455,21 @@ class RubberAnimationController extends Animation<double>
   @override
   String toStringDetails() {
     final String paused = isAnimating ? '' : '; paused';
-    final String ticker = _ticker == null ? '; DISPOSED' : (_ticker.muted ? '; silenced' : '');
+    final String ticker =
+        _ticker == null ? '; DISPOSED' : (_ticker!.muted ? '; silenced' : '');
     final String label = debugLabel == null ? '' : '; for $debugLabel';
-    final String more = '${super.toStringDetails()} ${value.toStringAsFixed(3)}';
+    final String more =
+        '${super.toStringDetails()} ${value.toStringAsFixed(3)}';
     return '$more$paused$ticker$label';
   }
 }
 
 class _InterpolationSimulation extends Simulation {
-  _InterpolationSimulation(this._begin, this._end, Duration duration, this._curve, double scale)
-      : assert(_begin != null),
-        assert(_end != null),
-        assert(duration != null && duration.inMicroseconds > 0),
-        _durationInSeconds = (duration.inMicroseconds * scale) / Duration.microsecondsPerSecond;
+  _InterpolationSimulation(
+      this._begin, this._end, Duration duration, this._curve, double scale)
+      : assert(duration.inMicroseconds > 0),
+        _durationInSeconds =
+            (duration.inMicroseconds * scale) / Duration.microsecondsPerSecond;
 
   final double _durationInSeconds;
   final double _begin;
@@ -472,13 +479,14 @@ class _InterpolationSimulation extends Simulation {
   @override
   double x(double timeInSeconds) {
     final double t = (timeInSeconds / _durationInSeconds).clamp(0.0, 1.0);
-      return _begin + (_end - _begin) * _curve.transform(t);
+    return _begin + (_end - _begin) * _curve.transform(t);
   }
 
   @override
   double dx(double timeInSeconds) {
     final double epsilon = tolerance.time;
-    return (x(timeInSeconds + epsilon) - x(timeInSeconds - epsilon)) / (2 * epsilon);
+    return (x(timeInSeconds + epsilon) - x(timeInSeconds - epsilon)) /
+        (2 * epsilon);
   }
 
   @override

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -21,7 +21,7 @@ class RubberBottomSheet extends StatefulWidget {
       this.scrollController,
       this.header,
       this.headerHeight = 50.0,
-      this.dragFriction = 0.48,
+      this.dragFriction = 0.52,
       this.onDragStart,
       this.onDragEnd,
       this.onTap})
@@ -31,6 +31,12 @@ class RubberBottomSheet extends StatefulWidget {
   final Widget lowerLayer;
   final Widget upperLayer;
   final Widget? menuLayer;
+
+  /// Friction to apply when the sheet reaches its bounds.
+  /// The higher the number, the more friction is applied.
+  /// Defaults to 0.52.
+  ///
+  /// Warning: If `dragFriction < 0`, your bottom sheet will accelerate off the screen.
   final double dragFriction;
   final Function? onTap;
 
@@ -42,7 +48,7 @@ class RubberBottomSheet extends StatefulWidget {
   /// won't complete the next onDragEnd instructions
   final Function()? onDragStart;
 
-  /// The widget on top of the rest of the bottom sheet.)
+  /// The widget on top of the rest of the bottom sheet.
   /// Usually used to make a non-scrollable area
   final Widget? header;
   // Parameter to change the header height, it's the only way to set the header height
@@ -249,10 +255,10 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
           diff = controller.upperBound! - controller.value;
         }
         if (diff != null) {
-          friction = widget.dragFriction * pow(1 - diff, 2);
+          friction = 1 + (widget.dragFriction * pow(1 - diff, 2));
         }
 
-        controller.value -= details.primaryDelta! / (_screenHeight * friction);
+        controller.value -= details.primaryDelta! / _screenHeight / friction;
         if (_shouldScroll &&
             controller.value >= controller.upperBound! &&
             !_draggingPeak(_lastPosition)) {

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -11,10 +11,10 @@ const double _kCompleteFlingVelocity = 5000.0;
 
 class RubberBottomSheet extends StatefulWidget {
   const RubberBottomSheet(
-      {Key key,
-      @required this.animationController,
-      @required this.lowerLayer,
-      @required this.upperLayer,
+      {Key? key,
+      required this.animationController,
+      required this.lowerLayer,
+      required this.upperLayer,
       this.menuLayer,
       this.scrollController,
       this.header,
@@ -23,27 +23,26 @@ class RubberBottomSheet extends StatefulWidget {
       this.onDragStart,
       this.onDragEnd,
       this.onTap})
-      : assert(animationController != null),
-        super(key: key);
+      : super(key: key);
 
-  final ScrollController scrollController;
+  final ScrollController? scrollController;
   final Widget lowerLayer;
   final Widget upperLayer;
-  final Widget menuLayer;
+  final Widget? menuLayer;
   final double dragFriction;
-  final Function onTap;
+  final Function? onTap;
 
   /// Called when the user stops scrolling, if this function returns a false the bottomsheet
   /// won't complete the next onDragEnd instructions
-  final Function() onDragEnd;
+  final Function()? onDragEnd;
 
   /// Called when the user stops scrolling, if this function returns a false the bottomsheet
   /// won't complete the next onDragEnd instructions
-  final Function() onDragStart;
+  final Function()? onDragStart;
 
   /// The widget on top of the rest of the bottom sheet.
   /// Usually used to make a non-scrollable area
-  final Widget header;
+  final Widget? header;
   // Parameter to change the header height, it's the only way to set the header height
   final double headerHeight;
 
@@ -51,11 +50,9 @@ class RubberBottomSheet extends StatefulWidget {
   /// animation state
   final RubberAnimationController animationController;
 
-  static RubberBottomSheetState of(BuildContext context,
+  static RubberBottomSheetState? of(BuildContext context,
       {bool nullOk = false}) {
-    assert(nullOk != null);
-    assert(context != null);
-    final RubberBottomSheetState result =
+    final RubberBottomSheetState? result =
         context.findAncestorStateOfType<RubberBottomSheetState>();
     if (nullOk || result != null) return result;
     throw FlutterError(
@@ -70,13 +67,14 @@ class RubberBottomSheet extends StatefulWidget {
 
 class RubberBottomSheetState extends State<RubberBottomSheet>
     with TickerProviderStateMixin, AfterLayoutMixin<RubberBottomSheet> {
-  double _screenHeight;
+  late double _screenHeight;
 
   final GlobalKey _keyPeak = GlobalKey();
   final GlobalKey _keyWidget = GlobalKey(debugLabel: 'bottomsheet menu key');
 
   double get _bottomSheetHeight {
-    final RenderBox renderBox = _keyWidget.currentContext.findRenderObject();
+    final RenderBox renderBox =
+        _keyWidget.currentContext!.findRenderObject() as RenderBox;
     return renderBox.size.height;
   }
 
@@ -85,14 +83,14 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
   bool get halfState => controller.halfBound != null;
 
   bool get _shouldScroll =>
-      _scrollController != null && _scrollController.hasClients;
+      _scrollController != null && _scrollController!.hasClients;
   bool _scrolling = false;
 
   bool get _hasHeader => widget.header != null;
 
   /// Adding [substituteScrollController] a value the bottomsheet will change the default one
-  ScrollController substituteScrollController;
-  ScrollController get _scrollController =>
+  ScrollController? substituteScrollController;
+  ScrollController? get _scrollController =>
       substituteScrollController ?? widget.scrollController;
 
   /// If set true the drag won't move the bottomsheet but the scrolling will be always active
@@ -127,7 +125,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
     });
   }
 
-  Widget _buildSlideAnimation(BuildContext context, Widget child) {
+  Widget _buildSlideAnimation(BuildContext context, Widget? child) {
     var layout;
     if (widget.menuLayer != null) {
       layout = Stack(
@@ -142,7 +140,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
       layout = _buildAnimatedBottomsheetWidget(context, child);
     }
     return GestureDetector(
-      onTap: widget.onTap,
+      onTap: widget.onTap as void Function()?,
       onVerticalDragDown: _onVerticalDragDown,
       onVerticalDragUpdate: _onVerticalDragUpdate,
       onVerticalDragEnd: _onVerticalDragEnd,
@@ -152,7 +150,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
     );
   }
 
-  Widget _buildAnimatedBottomsheetWidget(BuildContext context, Widget child) {
+  Widget _buildAnimatedBottomsheetWidget(BuildContext context, Widget? child) {
     var heightFactor = widget.animationController.value >= 0
         ? widget.animationController.value
         : 0.0;
@@ -198,8 +196,8 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
   }
 
   // Touch gestures
-  Drag _drag;
-  ScrollHoldController _hold;
+  Drag? _drag;
+  ScrollHoldController? _hold;
 
   void _onVerticalDragDown(DragDownDetails details) {
     if (_enabled) {
@@ -212,12 +210,12 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
       }
       if (_shouldScroll) {
         assert(_hold == null);
-        _hold = _scrollController.position.hold(_disposeHold);
+        _hold = _scrollController!.position.hold(_disposeHold);
       }
     }
   }
 
-  Offset _lastPosition;
+  Offset? _lastPosition;
 
   void _onVerticalDragUpdate(DragUpdateDetails details) {
     if (_enabled) {
@@ -226,47 +224,47 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
         // _drag might be null if the drag activity ended and called _disposeDrag.
         assert(_hold == null || _drag == null);
         _drag?.update(details);
-        if (_scrollController.position.pixels <= 0 &&
-            details.primaryDelta > 0 &&
+        if (_scrollController!.position.pixels <= 0 &&
+            details.primaryDelta! > 0 &&
             !_forceScrolling) {
           _setScrolling(false);
           _handleDragCancel();
-          if (_scrollController.position.pixels != 0.0) {
-            _scrollController.position.setPixels(0.0);
+          if (_scrollController!.position.pixels != 0.0) {
+            _scrollController!.position.setPixels(0.0);
           }
         }
       } else {
         var friction = 1.0;
         var diff;
         // Friction if more than upper
-        if (controller.value > controller.upperBound) {
-          diff = controller.value - controller.upperBound;
+        if (controller.value > controller.upperBound!) {
+          diff = controller.value - controller.upperBound!;
         }
         // Friction if less than lower
-        else if (controller.value < controller.lowerBound) {
-          diff = controller.lowerBound - controller.value;
+        else if (controller.value < controller.lowerBound!) {
+          diff = controller.lowerBound! - controller.value;
         }
-        if (controller.value < controller.upperBound &&
+        if (controller.value < controller.upperBound! &&
             controller.dismissable &&
             controller.animationState.value == AnimationState.expanded) {
-          diff = controller.upperBound - controller.value;
+          diff = controller.upperBound! - controller.value;
         }
         if (diff != null) {
           friction = widget.dragFriction * pow(1 - diff, 2);
         }
 
-        controller.value -= details.primaryDelta / _screenHeight * friction;
+        controller.value -= details.primaryDelta! / _screenHeight * friction;
         if (_shouldScroll &&
-            controller.value >= controller.upperBound &&
+            controller.value >= controller.upperBound! &&
             !_draggingPeak(_lastPosition)) {
-          controller.value = controller.upperBound;
+          controller.value = controller.upperBound!;
 
           _setScrolling(true);
           var startDetails = DragStartDetails(
               sourceTimeStamp: details.sourceTimeStamp,
               globalPosition: details.globalPosition);
-          _hold = _scrollController.position.hold(_disposeHold);
-          _drag = _scrollController.position.drag(startDetails, _disposeDrag);
+          _hold = _scrollController!.position.hold(_disposeHold);
+          _drag = _scrollController!.position.drag(startDetails, _disposeDrag);
         } else {
           _handleDragCancel();
         }
@@ -282,13 +280,13 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
 
   void _handleDragStart(DragStartDetails details) {
     if (_enabled) {
-      if (widget.onDragStart != null) widget.onDragStart();
+      if (widget.onDragStart != null) widget.onDragStart!();
       if (_shouldScroll) {
         // It's possible for _hold to become null between _handleDragDown and
         // _handleDragStart, for example if some user code calls jumpTo or otherwise
         // triggers a new activity to begin.
         assert(_drag == null);
-        _drag = _scrollController.position.drag(details, _disposeDrag);
+        _drag = _scrollController!.position.drag(details, _disposeDrag);
         assert(_drag != null);
         assert(_hold == null);
       }
@@ -299,7 +297,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
     if (_enabled) {
       // If onDragEnd returns a false value the method interrupts
       if (widget.onDragEnd != null) {
-        var res = widget.onDragEnd();
+        var res = widget.onDragEnd!();
         if (res != null && !res) return;
       }
 
@@ -318,7 +316,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
           if (halfState) {
             if (details.velocity.pixelsPerSecond.dy.abs() >
                 _kMinFlingVelocity) {
-              if (controller.value > controller.halfBound) {
+              if (controller.value > controller.halfBound!) {
                 controller.fling(controller.halfBound, controller.upperBound,
                     velocity: flingVelocity);
               } else {
@@ -327,10 +325,10 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
               }
             } else {
               if (controller.value >
-                  (controller.upperBound + controller.halfBound) / 2) {
+                  (controller.upperBound! + controller.halfBound!) / 2) {
                 controller.expand();
               } else if (controller.value >
-                  (controller.halfBound + controller.lowerBound) / 2) {
+                  (controller.halfBound! + controller.lowerBound!) / 2) {
                 controller.halfExpand();
               } else {
                 controller.collapse();
@@ -343,7 +341,7 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
                   velocity: flingVelocity);
             } else {
               if (controller.value >
-                  (controller.upperBound + controller.lowerBound) / 2) {
+                  (controller.upperBound! + controller.lowerBound!) / 2) {
                 controller.expand();
               } else {
                 controller.collapse();
@@ -380,12 +378,13 @@ class RubberBottomSheetState extends State<RubberBottomSheet>
     });
   }
 
-  bool _draggingPeak(Offset globalPosition) {
+  bool _draggingPeak(Offset? globalPosition) {
     if (!_hasHeader) return false;
-    final RenderBox renderBoxRed = _keyPeak.currentContext.findRenderObject();
+    final RenderBox renderBoxRed =
+        _keyPeak.currentContext!.findRenderObject() as RenderBox;
     final positionPeak = renderBoxRed.localToGlobal(Offset.zero);
     final sizePeak = renderBoxRed.size;
     final top = (sizePeak.height + positionPeak.dy);
-    return (globalPosition.dy < top);
+    return (globalPosition!.dy < top);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: after_layout
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.7+1"
+    version: "1.1.0"
   async:
     dependency: transitive
     description:
@@ -150,4 +150,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: rubber
 description: Rubber is an elastic bottom sheet widget with the customizable material spring animation.
-version: 0.5.0
+version: 1.0.0
 homepage: https://github.com/mcrovero/rubber
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
closes #53

This is pretty much the same change as #54, except that:
* It is carefully merged onto #65 
* I replaced `AnimationPadding.none()` with `AnimationPadding.bottomOnly()` because that is _actually_ what the old default behavior was, getting rid of the easy fling offscreen issue
* I added an example of how to use various padding options